### PR TITLE
_get_resource_data in resources.py throws

### DIFF
--- a/healthgraph/parser.py
+++ b/healthgraph/parser.py
@@ -78,6 +78,8 @@ def parse_distance_km(val):
     
 def parse_resource_dict(prop_defs, data):
     prop_dict = dict([(k, None) for k in prop_defs])
+    if callable(data):
+        data = data()
     for k,v in data.items():
         if prop_defs.has_key(k):
             action = prop_defs[k]

--- a/healthgraph/resources.py
+++ b/healthgraph/resources.py
@@ -89,7 +89,7 @@ class APIobject(object):
             
     def _get_resource_data(self, resource, content_type, params=None):
         resp = self._session.get(resource, content_type, params)
-        return resp.json() # TODO - Error Checking
+        return resp.json # TODO - Error Checking
     
     def _get_linked_resource(self, link, cls_override=None, **kwargs):
         if link is not None:


### PR DESCRIPTION
I just removed the parens so that resp.json is returned and made sure it is never a callable.
