### PR TITLE
added missing fields to FitnessActivityFeedItem

### DIFF
--- a/healthgraph/resources.py
+++ b/healthgraph/resources.py
@@ -577,6 +577,9 @@ class FitnessActivityFeedItem(FeedItem):
                   'type': None,
                   'duration': None,
                   'total_distance': parse_distance,
+                  'total_calories': None,
+                  'has_path': parse_bool,
+                  'entry_mode': None,
                   'uri': PropResourceLink('FitnessActivity'),
                   }
     _prop_main = ('type', 'start_time',)


### PR DESCRIPTION
`FitnessActivityFeedItem` class was missing `total_calories`, `has_path` and `entry_mode` fields existing in the API response
