### PR TITLE
add  field to FitnessActivity

### DIFF
--- a/healthgraph/resources.py
+++ b/healthgraph/resources.py
@@ -518,6 +518,7 @@ class FitnessActivity(Resource):
                   'path': ArrayPath,
                   'images': ArrayImages,
                   'source': None,
+                  'entry_mode': None,
                   'activity': None,
                   'comments': PropResourceLink('CommentThread'),
                   'previous': PropResourceLink('FitnessActivity'),

--- a/healthgraph/resources.py
+++ b/healthgraph/resources.py
@@ -504,6 +504,7 @@ class FitnessActivity(Resource):
                   'secondary_type': None,
                   'equipment': None,
                   'start_time': parse_datetime,
+                  'utc_offset': None,
                   'total_distance': parse_distance,
                   'distance': ArrayDistance,
                   'duration': None,


### PR DESCRIPTION
The fitness activity lacks a `utc_offset` field necessary to determine activity timezone.
http://runkeeper.com/developer/healthgraph/fitness-activities#past
