### PR TITLE
Properly format date params.

### DIFF
--- a/healthgraph/parser.py
+++ b/healthgraph/parser.py
@@ -91,7 +91,7 @@ def parse_resource_dict(prop_defs, data):
 
 def parse_date_param(val):
     if isinstance(val, (date, datetime)):
-        return val.strftime('%y-%m-%d')
+        return val.strftime('%Y-%m-%d')
     else:
         return val
 


### PR DESCRIPTION
From the docs:

```
The noEarlierThan, noLaterThan, modifiedNoEarlierThan, and modifiedNoLaterThan query 
parameters restrict the scope of the returned feed. Each takes a date in YYYY-MM-DD 
format.
```

http://runkeeper.com/developer/healthgraph/example-api-calls#get
